### PR TITLE
Adds workflow to update Wanikani data weekly

### DIFF
--- a/.github/workflows/update-wk-data.yaml
+++ b/.github/workflows/update-wk-data.yaml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/.github/workflows/update-wk-data.yaml
+++ b/.github/workflows/update-wk-data.yaml
@@ -1,0 +1,52 @@
+name: Update Wanikani Data
+
+on:
+  # Every week on Sunday at 10AM
+  schedule:
+    - cron: '0 10 * * 0'
+  # Allows manual triggering of the workflow
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-wk-data:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: 'package-lock.json'
+
+      - name: Update Wanikani data
+        env:
+          WK_API_KEY: ${{ secrets.WK_API_KEY }}
+        run: |
+          node ./tools/updateWanikaniData.js
+
+      - name: If there are no commits, exit
+        run: |
+            if git diff --quiet; then
+                echo "No changes detected"
+                exit 0
+            else
+                echo "Changes detected"
+            fi
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+            commit-message: ":bento: Updates Wanikani data"
+            branch: automation/update-wanikani-data-${{ github.run_id }}
+            title: "Updates Wanikani data"
+            body: "This PR updates the Wanikani data to the latest version."
+            draft: false
+            base: main

--- a/tools/updateWanikaniData.js
+++ b/tools/updateWanikaniData.js
@@ -1,0 +1,63 @@
+import fs from 'fs';
+import process from 'node:process';
+import { URLSearchParams } from 'node:url';
+
+import fetch from 'node-fetch';
+
+const WRITE_LOCATION = './libs/printer/assets/sources/wanikani';
+const WK_API_KEY = process.env.WK_API_KEY;
+
+const updateWanikaniData = async () => {
+    // Ensure API key is set
+    if (!process.env.WK_API_KEY) {
+        throw new Error('Wanikani API key is not set in environment variables.');
+    }
+
+    // Ensure the directory exists
+    if (!fs.existsSync(WRITE_LOCATION)) {
+        fs.mkdirSync(WRITE_LOCATION, { recursive: true });
+    }
+
+    const levels = Array.from({ length: 60 }, (_, i) => i + 1);
+    await Promise.all(
+        levels.map(async (level) => {
+            const paramsString = new URLSearchParams({
+                levels: level,
+                types: 'kanji',
+                hidden: false
+            }).toString();
+
+            const apiResponse = await fetch(
+                `https://api.wanikani.com/v2/subjects?${paramsString}`,
+                {
+                    method: 'GET',
+                    headers: {
+                        'Wanikani-Revision': '20170710',
+                        Authorization: `Bearer ${WK_API_KEY}`
+                    }
+                }
+            );
+            if (!apiResponse.ok) {
+                throw new Error(
+                    `Wanikani API request failed with status ${apiResponse.status}: ${apiResponse.statusText}`
+                );
+            }
+
+            const response = await apiResponse.json();
+            const sortedKanji = response.data.sort((a, b) => a.lesson_position - b.lesson_position);
+            const levelData = sortedKanji.map((item) => item.data.slug).join('\n');
+            const writePath = `${WRITE_LOCATION}/${level}.source`;
+            fs.writeFileSync(writePath, levelData + '\n');
+        })
+    );
+};
+
+updateWanikaniData()
+    .then((result) => {
+        console.log('Wanikani source update completed:', result);
+        process.exit(0);
+    })
+    .catch((error) => {
+        console.error('Error updating Wanikani source:', error);
+        process.exit(1);
+    });

--- a/tools/updateWanikaniData.js
+++ b/tools/updateWanikaniData.js
@@ -9,7 +9,7 @@ const WK_API_KEY = process.env.WK_API_KEY;
 
 const updateWanikaniData = async () => {
     // Ensure API key is set
-    if (!process.env.WK_API_KEY) {
+    if (!WK_API_KEY) {
         throw new Error('Wanikani API key is not set in environment variables.');
     }
 
@@ -53,8 +53,8 @@ const updateWanikaniData = async () => {
 };
 
 updateWanikaniData()
-    .then((result) => {
-        console.log('Wanikani source update completed:', result);
+    .then(() => {
+        console.log('Wanikani source update completed successfully.');
         process.exit(0);
     })
     .catch((error) => {


### PR DESCRIPTION
#### Why️?

Wanikani data keeps getting outdated.


#### What Changed?

This pull request introduces automation for updating Wanikani kanji data and adds a script to fetch and store this data from the Wanikani API. The main changes include adding a GitHub Actions workflow to schedule and automate updates, and implementing a Node.js script to fetch the latest kanji data and write it to the appropriate directory.

**Automation and workflow:**

* Added a new GitHub Actions workflow (`.github/workflows/update-wk-data.yaml`) that runs weekly and can also be triggered manually. This workflow checks out the repository, sets up Node.js, runs the data update script, and creates a pull request if there are changes.

**Data fetching and processing:**

* Implemented `tools/updateWanikaniData.js`, a Node.js script that fetches kanji data for all 60 Wanikani levels from the official API, sorts the kanji by lesson position, and writes them to level-specific files in `./libs/printer/assets/sources/wanikani`. The script handles missing API keys and errors gracefully.
[Copilot is generating a summary...]

#### Related issue/PRs
#403 
#445


